### PR TITLE
feat: Add HATEOAS support to Category API with pagination and validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
-
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-hateoas</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>

--- a/src/main/java/com/ostia/productcatalogservice/assembler/CategoryModelAssembler.java
+++ b/src/main/java/com/ostia/productcatalogservice/assembler/CategoryModelAssembler.java
@@ -1,0 +1,25 @@
+package com.ostia.productcatalogservice.assembler;
+
+import com.ostia.productcatalogservice.controller.CategoryController;
+import com.ostia.productcatalogservice.dto.CategoryDTO;
+import com.ostia.productcatalogservice.dto.UpdateCategoryDTO;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.server.RepresentationModelAssembler;
+import org.springframework.stereotype.Component;
+import static com.ostia.productcatalogservice.common.LinkRelation.*;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
+
+@Component
+public class CategoryModelAssembler implements RepresentationModelAssembler<CategoryDTO, EntityModel<CategoryDTO>> {
+
+    @Override
+    public EntityModel<CategoryDTO> toModel(CategoryDTO categoryDTO) {
+        return EntityModel.of(
+                categoryDTO,
+                linkTo(methodOn(CategoryController.class).getCategory(categoryDTO.name())).withSelfRel(),
+                linkTo(methodOn(CategoryController.class).deleteCategory(categoryDTO.name())).withRel(DELETE.rel()),
+                linkTo(methodOn(CategoryController.class).updateCategory(categoryDTO.name(), new UpdateCategoryDTO(categoryDTO.description()))).withRel(UPDATE.rel())
+        );
+    }
+}

--- a/src/main/java/com/ostia/productcatalogservice/common/LinkRelation.java
+++ b/src/main/java/com/ostia/productcatalogservice/common/LinkRelation.java
@@ -1,0 +1,17 @@
+package com.ostia.productcatalogservice.common;
+
+public enum LinkRelation {
+
+    DELETE("delete"),
+    UPDATE("update");
+
+    private final String rel;
+
+    LinkRelation(String rel) {
+        this.rel = rel;
+    }
+
+    public String rel() {
+        return rel;
+    }
+}

--- a/src/main/java/com/ostia/productcatalogservice/dto/CategoryDTO.java
+++ b/src/main/java/com/ostia/productcatalogservice/dto/CategoryDTO.java
@@ -3,5 +3,5 @@ package com.ostia.productcatalogservice.dto;
 import jakarta.validation.constraints.NotBlank;
 
 public record CategoryDTO(@NotBlank String name,
-                          String description) {
+                          @NotBlank String description) {
 }

--- a/src/main/java/com/ostia/productcatalogservice/dto/UpdateCategoryDTO.java
+++ b/src/main/java/com/ostia/productcatalogservice/dto/UpdateCategoryDTO.java
@@ -1,0 +1,6 @@
+package com.ostia.productcatalogservice.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdateCategoryDTO(@NotBlank String description) {
+}

--- a/src/main/java/com/ostia/productcatalogservice/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ostia/productcatalogservice/exception/GlobalExceptionHandler.java
@@ -1,6 +1,6 @@
 package com.ostia.productcatalogservice.exception;
 
-import com.ostia.productcatalogservice.util.MessageResolver;
+import com.ostia.productcatalogservice.util.CustomMessageResolver;
 import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,9 +17,9 @@ import java.util.Objects;
 public class GlobalExceptionHandler {
 
     private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
-    private final MessageResolver messages;
+    private final CustomMessageResolver messages;
 
-    public GlobalExceptionHandler(MessageResolver messages) {
+    public GlobalExceptionHandler(CustomMessageResolver messages) {
         this.messages = messages;
     }
 

--- a/src/main/java/com/ostia/productcatalogservice/repository/CategoryRepository.java
+++ b/src/main/java/com/ostia/productcatalogservice/repository/CategoryRepository.java
@@ -2,6 +2,7 @@ package com.ostia.productcatalogservice.repository;
 
 import com.ostia.productcatalogservice.model.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface CategoryRepository extends JpaRepository<Category, UUID> {
@@ -9,4 +10,5 @@ public interface CategoryRepository extends JpaRepository<Category, UUID> {
     boolean existsByName(String name);
     Category findByName(String name);
     void deleteByName(String name);
+    Optional<Category> findByNameIgnoreCase(String name);
 }

--- a/src/main/java/com/ostia/productcatalogservice/service/CategoryService.java
+++ b/src/main/java/com/ostia/productcatalogservice/service/CategoryService.java
@@ -1,10 +1,13 @@
 package com.ostia.productcatalogservice.service;
 
 import com.ostia.productcatalogservice.dto.CategoryDTO;
+import com.ostia.productcatalogservice.dto.UpdateCategoryDTO;
 import com.ostia.productcatalogservice.exception.EntityAlreadyExistsException;
 import com.ostia.productcatalogservice.exception.EntityNotFoundException;
 import com.ostia.productcatalogservice.mapper.DomainMapper;
 import com.ostia.productcatalogservice.repository.CategoryRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import java.util.UUID;
@@ -22,8 +25,8 @@ public class CategoryService {
     public UUID addCategory(CategoryDTO categoryDTO) {
         var category = DomainMapper.DTOToEntity(categoryDTO);
 
-        if(!categoryRepository.existsByName(category.getName())) {
-            var savedCategory =  categoryRepository.save(category);
+        if (!categoryRepository.existsByName(category.getName())) {
+            var savedCategory = categoryRepository.save(category);
             return savedCategory.getId();
         }
 
@@ -39,11 +42,24 @@ public class CategoryService {
     }
 
     @Transactional
-    public void deleteCategory(String catName){
+    public void deleteCategory(String catName) {
 
-        if(!categoryRepository.existsByName(catName)){
+        if (!categoryRepository.existsByName(catName)) {
             throw new EntityNotFoundException("Category", "name", catName);
         }
         categoryRepository.deleteByName(catName);
+    }
+
+    public void updateCategory(String name, UpdateCategoryDTO dto) {
+        var category = categoryRepository.findByNameIgnoreCase(name)
+                .orElseThrow(() -> new EntityNotFoundException("Category", "name", name));
+
+        category.setDescription(dto.description());
+        categoryRepository.save(category);
+    }
+
+    public Page<CategoryDTO> getAllCategories(Pageable pageable) {
+        return categoryRepository.findAll(pageable)
+                .map(DomainMapper::EntityToDTO);
     }
 }

--- a/src/main/java/com/ostia/productcatalogservice/util/CustomMessageResolver.java
+++ b/src/main/java/com/ostia/productcatalogservice/util/CustomMessageResolver.java
@@ -5,11 +5,11 @@ import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.stereotype.Component;
 
 @Component
-public class MessageResolver {
+public class CustomMessageResolver {
 
     private final MessageSource messageSource;
 
-    public MessageResolver(MessageSource messageSource) {
+    public CustomMessageResolver(MessageSource messageSource) {
         this.messageSource = messageSource;
     }
 

--- a/src/test/java/com/ostia/productcatalogservice/service/CategoryServiceTest.java
+++ b/src/test/java/com/ostia/productcatalogservice/service/CategoryServiceTest.java
@@ -1,18 +1,28 @@
 package com.ostia.productcatalogservice.service;
 
 import com.ostia.productcatalogservice.dto.CategoryDTO;
+import com.ostia.productcatalogservice.dto.UpdateCategoryDTO;
 import com.ostia.productcatalogservice.exception.EntityAlreadyExistsException;
 import com.ostia.productcatalogservice.exception.EntityNotFoundException;
 import com.ostia.productcatalogservice.mapper.DomainMapper;
 import com.ostia.productcatalogservice.model.Category;
 import com.ostia.productcatalogservice.repository.CategoryRepository;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
+
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.Mockito.*;
@@ -110,5 +120,48 @@ public class CategoryServiceTest {
 
         verify(categoryRepository).existsByName(categoryName);
         verify(categoryRepository, never()).findByName(any());
+    }
+
+    @Test
+    void shouldUpdateCategoryDescription() {
+        // Given
+        String name = "Books";
+        Category category = new Category();
+        category.setId(UUID.randomUUID());
+        category.setName(name);
+        category.setDescription("Old description");
+
+        when(categoryRepository.findByNameIgnoreCase(name)).thenReturn(Optional.of(category));
+
+        UpdateCategoryDTO updateDTO = new UpdateCategoryDTO("New updated description");
+
+        // When
+        categoryService.updateCategory(name, updateDTO);
+
+        // Then
+        assertThat(category.getDescription()).isEqualTo("New updated description");
+        verify(categoryRepository).save(category);
+    }
+
+    @Test
+    void shouldReturnPagedCategoryDTOs() {
+        // Given
+        Category category = new Category();
+        category.setId(UUID.randomUUID());
+        category.setName("Music");
+        category.setDescription("All music items");
+
+        Page<Category> categoryPage = new PageImpl<>(List.of(category));
+        Pageable pageable = PageRequest.of(0, 10);
+
+        when(categoryRepository.findAll(pageable)).thenReturn(categoryPage);
+
+        // When
+        Page<CategoryDTO> result = categoryService.getAllCategories(pageable);
+
+        Assertions.assertThat(result.getContent()).hasSize(1);
+        // Then
+        assertThat(result.getContent().get(0).name()).isEqualTo("Music");
+        assertThat(result.getContent().get(0).description()).isEqualTo("All music items");
     }
 }


### PR DESCRIPTION
- Added `CategoryModelAssembler` to generate HATEOAS links (self, update, delete)
- Updated `CategoryController` to support paginated GET endpoint with HATEOAS response
- Introduced input validation on `page` and `size` query parameters
- Refactored `/categories?name={}` into RESTful `/categories/{name}`
- Created `UpdateCategoryDTO` for update endpoint
- Implemented updateCategory logic in service and controller layers
- Added integration and unit tests for pagination, validation, and update flows
- Added `spring-boot-starter-hateoas` dependency