### PR TITLE
feat: configure Spring Boot Actuator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
-
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,10 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-hateoas</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
 		<dependency>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -27,3 +27,9 @@ spring.messages.basename=error,validation,logging-messages
 # for proper encoding of special characters
 spring.messages.encoding=UTF-8
 spring.profiles.active=test
+
+# Expose all actuator endpoints
+management.endpoints.web.exposure.include=*
+
+# Exclude specific endpoints like env and beans
+management.endpoints.web.exposure.exclude=env,beans


### PR DESCRIPTION
- Add spring-boot-starter-actuator dependency to enable Actuator endpoints.
- Expose  endpoints via application.properties with: management.endpoints.web.exposure.include=* management.endpoints.web.exposure.exclude=env,beans